### PR TITLE
Fix SourceMap loading in Hot Reloader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,6 @@ if (process.env.HOT) {
   config.entry['index.ios'].unshift('react-native-webpack-server/hot/entry')
   config.entry['index.ios'].unshift('webpack/hot/only-dev-server')
   config.entry['index.ios'].unshift('webpack-dev-server/client?http://localhost:8082')
-  config.output.publicPath = 'http://localhost:8082/'
   config.plugins.unshift(new webpack.HotModuleReplacementPlugin())
   config.module.loaders[0].query.plugins.push('react-transform')
   config.module.loaders[0].query.extra = {


### PR DESCRIPTION
- Fixes
  https://github.com/adampash/react-native-hot-redux-starter/issues/3
  by removing publicPath declaration. Usage remains the same.
