### PR TITLE
Fix babel-plugin-react-transform config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,11 +43,13 @@ if (process.env.HOT) {
   config.plugins.unshift(new webpack.HotModuleReplacementPlugin())
   config.module.loaders[0].query.plugins.push('react-transform')
   config.module.loaders[0].query.extra = {
-    'react-transform': [{
-      target: 'react-transform-hmr',
-      imports: ['react-native'],
-      locals: ['module']
-    }]
+    'react-transform': {
+      transforms: [{
+        transform: 'react-transform-hmr',
+        imports: ['react-native'],
+        locals: ['module']
+      }]
+    }
   }
 }
 


### PR DESCRIPTION
- update configuration to use new syntax
- removes warning displayed
- Ref
  https://github.com/gaearon/babel-plugin-react-transform/releases/tag/v1.1.0
